### PR TITLE
Add 90 degree rotation to clock SVG

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -147,6 +147,7 @@ h1 {
   width: 100%;
   height: auto;
   filter: drop-shadow(0 10px 20px rgba(0, 0, 0, 0.1));
+  transform: rotate(90deg);
 }
 
 /* Clock Elements */


### PR DESCRIPTION
The clock coordinate system was oriented -90 degrees, so rotating the entire SVG 90 degrees clockwise makes the clock display right-side up.