### PR TITLE
Fix clock orientation - rotate hands only, not face

### DIFF
--- a/clock.js
+++ b/clock.js
@@ -144,7 +144,7 @@ for (let i = 0; i < 12; i++) {
 }
 
 const handsGroup = document.createElementNS("http://www.w3.org/2000/svg", "g");
-handsGroup.setAttribute("transform", "translate(150, 150)");
+handsGroup.setAttribute("transform", "translate(150, 150) rotate(90)");
 clockSVG.appendChild(handsGroup);
 
 const hourHand = document.createElementNS("http://www.w3.org/2000/svg", "line");

--- a/styles.css
+++ b/styles.css
@@ -147,7 +147,6 @@ h1 {
   width: 100%;
   height: auto;
   filter: drop-shadow(0 10px 20px rgba(0, 0, 0, 0.1));
-  transform: rotate(90deg);
 }
 
 /* Clock Elements */


### PR DESCRIPTION
Moved the 90 degree rotation from the entire SVG to just the hands group. This keeps the clock hands in the correct position while allowing the clock face, numbers, and wedges to display in their natural orientation.